### PR TITLE
Persist navigation menu

### DIFF
--- a/templates/homepage.lucius
+++ b/templates/homepage.lucius
@@ -28,6 +28,9 @@ nav {
     font-family: 'Lato';
     font-size: 0.80em;
     font-weight: 400;
+    position: fixed;
+    top: 0;
+    width: 100%;
     ul {
         margin: 0;
         padding: 0;
@@ -74,8 +77,9 @@ nav {
 div.headergroup {
     width: 1050px;
     margin: 0 auto;
-    position: relative;
-    padding-top: 1.3em;
+    padding-top: 2.6em;
+    display: flex;
+    flex-direction: row;
     padding-bottom: 1.3em;
     div.homepage-logo {
         text-align: center;
@@ -103,11 +107,7 @@ div.headergroup {
        font-weight: 300;
        font-size: 0.8em;
        line-height: 1.6em;
-       position: absolute;
-       left: 600px;
-       top: 0;
        width: 220px;
-       padding: 30px;
     }
 
     h2 {

--- a/templates/mobile.lucius
+++ b/templates/mobile.lucius
@@ -8,6 +8,11 @@
         display: none;
     }
 
+    /* Because of specificity we need to overriede display:flex from homepage.lucius */
+    div .headergroup {
+        display: none;
+    }        
+
     #container > nav {
         background-color: #fff;
         box-shadow: none;

--- a/templates/mobile.lucius
+++ b/templates/mobile.lucius
@@ -8,7 +8,7 @@
         display: none;
     }
 
-    /* Because of specificity we need to overriede display:flex from homepage.lucius */
+    /* Because of specificity we need to override display:flex from homepage.lucius */
     div .headergroup {
         display: none;
     }        


### PR DESCRIPTION
Right now when we scroll (both in desktop mode and mobile), the top
navigation menu disappears. This patch make sures that they persist.
Also, I have used flexbox in CSS to do that which simplifies the
current code (by removoal of absolute and relative positioning css code).