### PR TITLE
Have better margin in mobile view

### DIFF
--- a/templates/mobile.lucius
+++ b/templates/mobile.lucius
@@ -47,6 +47,11 @@
             }
         }
     }
+    
+    dd, p, dt {
+        margin: 12px;
+    }
+
 }
 
 @media print {


### PR DESCRIPTION
This is quite noticeable in my mobile view. Previously, the content used to stick to the edge of the screen. This patches makes it easy on the eyes.

Landscape view => 

Before: 
![landscape_before](https://user-images.githubusercontent.com/737477/27286198-e305c8d0-551c-11e7-9342-a826b92c0541.png)
After: 
![landscape_after](https://user-images.githubusercontent.com/737477/27286200-e31e4842-551c-11e7-97db-ffc0961a368d.png)

Portrait view:
Before:
![potrait_before](https://user-images.githubusercontent.com/737477/27286197-e30527ae-551c-11e7-841f-6de2e28047dd.png)
After:
After:
![potrait_after](https://user-images.githubusercontent.com/737477/27286199-e306b3f8-551c-11e7-9ea3-c855e568d894.png)



