### PR TITLE
Fix Disqus and gravatar: insecure content in https

### DIFF
--- a/src/Handler/Blog.hs
+++ b/src/Handler/Blog.hs
@@ -110,7 +110,7 @@ getContent post = do
 
 gravatar :: Text -> Text
 gravatar email = T.concat
-    [ "http://www.gravatar.com/avatar/"
+    [ "https://www.gravatar.com/avatar/"
     , hashEmail email
     , "?size=80"
     ]

--- a/templates/blog.hamlet
+++ b/templates/blog.hamlet
@@ -14,12 +14,12 @@ $newline never
     <p #comments>Comments
     <div id="disqus_thread">
     <p>
-      <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span>
+      <a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span>
 
 <script type="text/javascript">
   var disqus_shortname = 'yesoddocs';
   (function() {
   var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-  dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+  dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
   (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
   })();


### PR DESCRIPTION
Noticed that disqus comments are missing for me on yesodweb.com blog pages